### PR TITLE
feat: Add test for Day9.calculateShortestRoute

### DIFF
--- a/src/main/java/tar/calion/aoc/year2015/Day9.java
+++ b/src/main/java/tar/calion/aoc/year2015/Day9.java
@@ -1,5 +1,16 @@
 package tar.calion.aoc.year2015;
 
+// Import for Route, though not strictly necessary as it's in the same package
+import tar.calion.aoc.year2015.Route;
+
 public class Day9 {
 
+    public Day9(String routes) {
+        // Constructor logic will be added later
+    }
+
+    public Route calculateShortestRoute() {
+        // Implementation will be added later
+        return null;
+    }
 }

--- a/src/main/java/tar/calion/aoc/year2015/Route.java
+++ b/src/main/java/tar/calion/aoc/year2015/Route.java
@@ -1,0 +1,6 @@
+package tar.calion.aoc.year2015;
+
+import java.util.List;
+
+public record Route(List<String> waypoints, long distance) {
+}

--- a/src/test/java/tar/calion/aoc/year2015/Day9Test.java
+++ b/src/test/java/tar/calion/aoc/year2015/Day9Test.java
@@ -1,6 +1,9 @@
 package tar.calion.aoc.year2015;
 
 import org.junit.jupiter.api.Test;
+import tar.calion.aoc.year2015.Route;
+import java.util.List;
+import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -9,5 +12,23 @@ class Day9Test {
     @Test
     void solve() {
         // TODO: Add test cases
+    }
+
+    @Test
+    void testCalculateShortestRoute() {
+        String routesInput = """
+                London to Dublin = 464
+                London to Belfast = 518
+                Dublin to Belfast = 141
+                """;
+        Day9 day9 = new Day9(routesInput);
+        Route shortestRoute = day9.calculateShortestRoute();
+
+        // At this stage, the calculateShortestRoute method returns null.
+        // These assertions will fail (likely with a NullPointerException)
+        // until the method is implemented correctly.
+        List<String> expectedWaypoints = Arrays.asList("London", "Dublin", "Belfast");
+        assertEquals(expectedWaypoints, shortestRoute.waypoints());
+        assertEquals(605L, shortestRoute.distance());
     }
 }


### PR DESCRIPTION
Adds a test case to Day9Test to verify the functionality of the calculateShortestRoute method.

The test instantiates Day9 with a predefined set of routes: London to Dublin = 464
London to Belfast = 518
Dublin to Belfast = 141

It then calls calculateShortestRoute() and asserts that the returned Route object has the waypoints "London" -> "Dublin" -> "Belfast" and a total distance of 605.

A new record 'Route' is introduced to represent the result, containing a List<String> of waypoints and a long for the distance.

The calculateShortestRoute method in Day9.java is currently a stub returning null, so the new test is expected to fail until the method is implemented.