### PR TITLE
feat: Add longestRoute calculation to Day9

### DIFF
--- a/src/main/java/tar/calion/aoc/year2015/day9/Day9.java
+++ b/src/main/java/tar/calion/aoc/year2015/day9/Day9.java
@@ -52,15 +52,17 @@ public class Day9 {
     public Routes calculateRoutes() {
         List<String> shortestRouteWaypoints = null;
         long minDistance = Long.MAX_VALUE;
+        List<String> longestRouteWaypoints = null;
+        long maxDistance = Long.MIN_VALUE;
 
         // Short-circuit if there are no locations to process.
         if (locations.isEmpty()) {
-            return new Routes(new Route(Collections.emptyList(), 0));
+            return new Routes(new Route(Collections.emptyList(), 0), new Route(Collections.emptyList(), 0));
         }
 
         // Handle the single location case.
         if (locations.size() == 1) {
-            return new Routes(new Route(new ArrayList<>(locations), 0));
+            return new Routes(new Route(new ArrayList<>(locations), 0), new Route(new ArrayList<>(locations), 0));
         }
         
         Collection<String> locationCollection = new ArrayList<>(locations);
@@ -83,6 +85,11 @@ public class Day9 {
                     minDistance = currentTotalDistance;
                     shortestRouteWaypoints = new ArrayList<>(currentPermutation);
                 }
+                // Add logic for longest route
+                if (currentTotalDistance > maxDistance) {
+                    maxDistance = currentTotalDistance;
+                    longestRouteWaypoints = new ArrayList<>(currentPermutation);
+                }
             } catch (NullPointerException e) {
                 // This permutation is invalid because a path segment is missing; ignore it.
             }
@@ -90,10 +97,15 @@ public class Day9 {
 
         if (shortestRouteWaypoints == null) {
             // No valid route covering all locations was found (e.g., disconnected graph for all-city traversal,
-            // or no locations provided initially).
-            return new Routes(new Route(Collections.emptyList(), 0));
+            // or no locations provided initially). This also means no longest route.
+            return new Routes(new Route(Collections.emptyList(), 0), new Route(Collections.emptyList(), 0));
         }
         
-        return new Routes(new Route(shortestRouteWaypoints, minDistance));
+        // If shortestRouteWaypoints is not null, a valid path was found.
+        // This implies longestRouteWaypoints will also be non-null if at least one path was processed.
+        // If locations.size() >= 2, at least one permutation is processed.
+        // If that one permutation is valid, both shortest and longest will be set.
+        // If that one permutation is invalid, shortestRouteWaypoints would be null and handled above.
+        return new Routes(new Route(shortestRouteWaypoints, minDistance), new Route(longestRouteWaypoints, maxDistance));
     }
 }

--- a/src/main/java/tar/calion/aoc/year2015/day9/Routes.java
+++ b/src/main/java/tar/calion/aoc/year2015/day9/Routes.java
@@ -2,5 +2,5 @@ package tar.calion.aoc.year2015.day9;
 
 import tar.calion.aoc.year2015.day9.Route;
 
-public record Routes(Route shortestRoute) {
+public record Routes(Route shortestRoute, Route longestRoute) {
 }

--- a/src/test/java/tar/calion/aoc/year2015/day9/Day9Test.java
+++ b/src/test/java/tar/calion/aoc/year2015/day9/Day9Test.java
@@ -13,7 +13,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class Day9Test {
 
     @Test
-    void testCalculateShortestRoute_Original() {
+    void testCalculateRoutes_AdventOfCodeExample() {
         String routesInput = """
                 London to Dublin = 464
                 London to Belfast = 518
@@ -22,63 +22,99 @@ class Day9Test {
         Day9 day9 = new Day9(routesInput);
         Routes result = day9.calculateRoutes();
         Route shortestRoute = result.shortestRoute();
+        Route longestRoute = result.longestRoute();
 
         assertNotNull(shortestRoute, "Shortest route should not be null");
-        assertNotNull(shortestRoute.waypoints(), "Waypoints list should not be null");
-        assertFalse(shortestRoute.waypoints().isEmpty(), "Waypoints list should not be empty");
-        assertEquals(605L, shortestRoute.distance(), "Distance should be 605 for the given input");
+        assertNotNull(shortestRoute.waypoints(), "Shortest route waypoints list should not be null");
+        assertFalse(shortestRoute.waypoints().isEmpty(), "Shortest route waypoints list should not be empty");
+        assertEquals(605L, shortestRoute.distance(), "Shortest distance should be 605 for the given input");
         
-        List<String> expectedWaypoints1 = Arrays.asList("London", "Dublin", "Belfast");
-        List<String> expectedWaypoints2 = Arrays.asList("Belfast", "Dublin", "London");
+        List<String> expectedShortestWaypoints1 = Arrays.asList("London", "Dublin", "Belfast");
+        List<String> expectedShortestWaypoints2 = Arrays.asList("Belfast", "Dublin", "London");
+        assertTrue(expectedShortestWaypoints1.equals(shortestRoute.waypoints()) || expectedShortestWaypoints2.equals(shortestRoute.waypoints()),
+                "Shortest waypoints should be either [London, Dublin, Belfast] or [Belfast, Dublin, London]. Actual: " + shortestRoute.waypoints());
 
-        assertTrue(expectedWaypoints1.equals(shortestRoute.waypoints()) || expectedWaypoints2.equals(shortestRoute.waypoints()),
-                "Waypoints should be either [London, Dublin, Belfast] or [Belfast, Dublin, London]. Actual: " + shortestRoute.waypoints());
+        assertNotNull(longestRoute, "Longest route should not be null");
+        assertNotNull(longestRoute.waypoints(), "Longest route waypoints list should not be null");
+        assertFalse(longestRoute.waypoints().isEmpty(), "Longest route waypoints list should not be empty");
+        assertEquals(982L, longestRoute.distance(), "Longest distance should be 982 for the given input");
+
+        List<String> expectedLongestWaypoints1 = Arrays.asList("Dublin", "London", "Belfast");
+        List<String> expectedLongestWaypoints2 = Arrays.asList("Belfast", "London", "Dublin");
+        assertTrue(expectedLongestWaypoints1.equals(longestRoute.waypoints()) || expectedLongestWaypoints2.equals(longestRoute.waypoints()),
+                "Longest waypoints should be either [Dublin, London, Belfast] or [Belfast, London, Dublin]. Actual: " + longestRoute.waypoints());
     }
 
     @Test
     void testEmptyInputString() {
         Day9 day9 = new Day9("");
         Routes result = day9.calculateRoutes();
-        Route route = result.shortestRoute();
-        assertNotNull(route, "Route should not be null for empty input");
-        assertTrue(route.waypoints().isEmpty(), "Waypoints should be empty for empty input");
-        assertEquals(0L, route.distance(), "Distance should be 0 for empty input");
+        Route shortestRoute = result.shortestRoute();
+        Route longestRoute = result.longestRoute();
+
+        assertNotNull(shortestRoute, "Shortest route should not be null for empty input");
+        assertTrue(shortestRoute.waypoints().isEmpty(), "Shortest route waypoints should be empty for empty input");
+        assertEquals(0L, shortestRoute.distance(), "Shortest distance should be 0 for empty input");
+
+        assertNotNull(longestRoute, "Longest route should not be null for empty input");
+        assertTrue(longestRoute.waypoints().isEmpty(), "Longest route waypoints should be empty for empty input");
+        assertEquals(0L, longestRoute.distance(), "Longest distance should be 0 for empty input");
     }
 
     @Test
     void testNullInputString() {
         Day9 day9 = new Day9(null);
         Routes result = day9.calculateRoutes();
-        Route route = result.shortestRoute();
-        assertNotNull(route, "Route should not be null for null input");
-        assertTrue(route.waypoints().isEmpty(), "Waypoints should be empty for null input");
-        assertEquals(0L, route.distance(), "Distance should be 0 for null input");
+        Route shortestRoute = result.shortestRoute();
+        Route longestRoute = result.longestRoute();
+
+        assertNotNull(shortestRoute, "Shortest route should not be null for null input");
+        assertTrue(shortestRoute.waypoints().isEmpty(), "Shortest route waypoints should be empty for null input");
+        assertEquals(0L, shortestRoute.distance(), "Shortest distance should be 0 for null input");
+
+        assertNotNull(longestRoute, "Longest route should not be null for null input");
+        assertTrue(longestRoute.waypoints().isEmpty(), "Longest route waypoints should be empty for null input");
+        assertEquals(0L, longestRoute.distance(), "Longest distance should be 0 for null input");
     }
 
     @Test
     void testOneLocation() {
-        Day9 day9 = new Day9("Alpha to Alpha = 0");
+        Day9 day9 = new Day9("Alpha to Alpha = 0"); // Parser adds "Alpha", calculateRoutes handles single location
         Routes result = day9.calculateRoutes();
-        Route route = result.shortestRoute();
-        assertNotNull(route, "Route should not be null for one location");
-        assertEquals(1, route.waypoints().size(), "Should have one waypoint");
-        assertEquals("Alpha", route.waypoints().get(0), "Waypoint should be Alpha");
-        assertEquals(0L, route.distance(), "Distance should be 0 for one location");
+        Route shortestRoute = result.shortestRoute();
+        Route longestRoute = result.longestRoute();
+
+        assertNotNull(shortestRoute, "Shortest route should not be null for one location");
+        assertEquals(1, shortestRoute.waypoints().size(), "Shortest route should have one waypoint");
+        assertEquals("Alpha", shortestRoute.waypoints().get(0), "Shortest route waypoint should be Alpha");
+        assertEquals(0L, shortestRoute.distance(), "Shortest distance should be 0 for one location");
+
+        assertNotNull(longestRoute, "Longest route should not be null for one location");
+        assertEquals(1, longestRoute.waypoints().size(), "Longest route should have one waypoint");
+        assertEquals("Alpha", longestRoute.waypoints().get(0), "Longest route waypoint should be Alpha");
+        assertEquals(0L, longestRoute.distance(), "Longest distance should be 0 for one location");
     }
 
     @Test
     void testTwoLocationsSingleRoute() {
         Day9 day9 = new Day9("Alpha to Beta = 100");
         Routes result = day9.calculateRoutes();
-        Route route = result.shortestRoute();
-        assertNotNull(route, "Route should not be null");
-        assertEquals(2, route.waypoints().size(), "Should have two waypoints");
-        assertEquals(100L, route.distance(), "Distance should be 100");
+        Route shortestRoute = result.shortestRoute();
+        Route longestRoute = result.longestRoute();
 
-        List<String> expected1 = Arrays.asList("Alpha", "Beta");
-        List<String> expected2 = Arrays.asList("Beta", "Alpha");
-        assertTrue(expected1.equals(route.waypoints()) || expected2.equals(route.waypoints()),
-                "Waypoints should be [Alpha, Beta] or [Beta, Alpha]. Actual: " + route.waypoints());
+        assertNotNull(shortestRoute, "Shortest route should not be null");
+        assertEquals(2, shortestRoute.waypoints().size(), "Shortest route should have two waypoints");
+        assertEquals(100L, shortestRoute.distance(), "Shortest distance should be 100");
+        List<String> expectedWaypoints = Arrays.asList("Alpha", "Beta");
+        List<String> expectedWaypointsReverse = Arrays.asList("Beta", "Alpha");
+        assertTrue(expectedWaypoints.equals(shortestRoute.waypoints()) || expectedWaypointsReverse.equals(shortestRoute.waypoints()),
+                "Shortest waypoints should be [Alpha, Beta] or [Beta, Alpha]. Actual: " + shortestRoute.waypoints());
+
+        assertNotNull(longestRoute, "Longest route should not be null");
+        assertEquals(2, longestRoute.waypoints().size(), "Longest route should have two waypoints");
+        assertEquals(100L, longestRoute.distance(), "Longest distance should be 100");
+        assertTrue(expectedWaypoints.equals(longestRoute.waypoints()) || expectedWaypointsReverse.equals(longestRoute.waypoints()),
+                "Longest waypoints should be [Alpha, Beta] or [Beta, Alpha]. Actual: " + longestRoute.waypoints());
     }
 
     @Test
@@ -89,36 +125,51 @@ class Day9Test {
                 """;
         Day9 day9 = new Day9(routesInput);
         Routes result = day9.calculateRoutes();
-        Route route = result.shortestRoute();
-        assertNotNull(route, "Route should not be null");
-        assertTrue(route.waypoints().isEmpty(), "Waypoints should be empty for disconnected graph not allowing full traversal");
-        assertEquals(0L, route.distance(), "Distance should be 0 for no valid full route");
+        Route shortestRoute = result.shortestRoute();
+        Route longestRoute = result.longestRoute();
+
+        assertNotNull(shortestRoute, "Shortest route should not be null");
+        assertTrue(shortestRoute.waypoints().isEmpty(), "Shortest route waypoints should be empty for disconnected graph");
+        assertEquals(0L, shortestRoute.distance(), "Shortest distance should be 0 for no valid full route");
+
+        assertNotNull(longestRoute, "Longest route should not be null");
+        assertTrue(longestRoute.waypoints().isEmpty(), "Longest route waypoints should be empty for disconnected graph");
+        assertEquals(0L, longestRoute.distance(), "Longest distance should be 0 for no valid full route");
     }
 
     @Test
     void testThreeLocations_OnePairDisconnected() {
+        // This test implies that all locations given must be part of the path.
+        // Dublin - London - Paris. Distance: D-L (100) + L-P (200) = 300.
+        // This is the only possible path visiting all 3. So shortest = longest.
         String routesInput = """
                 London to Dublin = 100
                 London to Paris = 200
-                """;
+                """; // Implicitly, Dublin to Paris is not defined directly.
         Day9 day9 = new Day9(routesInput);
         Routes result = day9.calculateRoutes();
         Route shortestRoute = result.shortestRoute();
+        Route longestRoute = result.longestRoute();
         
         assertNotNull(shortestRoute, "Shortest route should not be null for this connected case.");
-        assertEquals(300L, shortestRoute.distance(), "Distance should be 300 for Dublin-London-Paris.");
-        assertFalse(shortestRoute.waypoints().isEmpty(), "Waypoints should not be empty.");
-        assertEquals(3, shortestRoute.waypoints().size(), "All 3 unique locations must be in the path.");
-
+        assertEquals(300L, shortestRoute.distance(), "Shortest distance should be 300 for Dublin-London-Paris.");
+        assertFalse(shortestRoute.waypoints().isEmpty(), "Shortest waypoints should not be empty.");
+        assertEquals(3, shortestRoute.waypoints().size(), "Shortest: All 3 unique locations must be in the path.");
         List<String> expectedWaypoints1 = Arrays.asList("Dublin", "London", "Paris");
         List<String> expectedWaypoints2 = Arrays.asList("Paris", "London", "Dublin");
-
         assertTrue(expectedWaypoints1.equals(shortestRoute.waypoints()) || expectedWaypoints2.equals(shortestRoute.waypoints()),
-                "Waypoints should be one of the expected paths. Actual: " + shortestRoute.waypoints());
+                "Shortest waypoints should be one of the expected paths. Actual: " + shortestRoute.waypoints());
+
+        assertNotNull(longestRoute, "Longest route should not be null for this connected case.");
+        assertEquals(300L, longestRoute.distance(), "Longest distance should be 300 for Dublin-London-Paris.");
+        assertFalse(longestRoute.waypoints().isEmpty(), "Longest waypoints should not be empty.");
+        assertEquals(3, longestRoute.waypoints().size(), "Longest: All 3 unique locations must be in the path.");
+        assertTrue(expectedWaypoints1.equals(longestRoute.waypoints()) || expectedWaypoints2.equals(longestRoute.waypoints()),
+                "Longest waypoints should be one of the expected paths. Actual: " + longestRoute.waypoints());
     }
 
     @Test
-    void testCalculateShortestRoute_ComplexGraph_Provided() {
+    void testCalculateRoutes_ComplexGraph_Provided() {
         String routesInput = """
                 Tristram to AlphaCentauri = 34
                 Tristram to Snowdin = 100
@@ -152,18 +203,28 @@ class Day9Test {
         Day9 day9 = new Day9(routesInput);
         Routes result = day9.calculateRoutes();
         Route shortestRoute = result.shortestRoute();
+        Route longestRoute = result.longestRoute();
 
         assertNotNull(shortestRoute, "Shortest route should not be null for complex graph");
-        assertEquals(251L, shortestRoute.distance(), "Distance for complex graph");
+        assertEquals(251L, shortestRoute.distance(), "Shortest distance for complex graph");
 
-        List<String> expectedWaypoints = Arrays.asList(
+        List<String> expectedShortestWaypoints = Arrays.asList(
             "Norrath", "Faerun", "Straylight", "Tristram", 
             "AlphaCentauri", "Snowdin", "Arbre", "Tambi"
         );
-        // If the implementation is deterministic, this direct check is fine.
-        // If multiple paths could give the same shortest distance with different orders,
-        // a more complex check (e.g., checking against a set of possible waypoint lists) would be needed.
-        // For now, we assume the identified shortest path order is what the current code produces.
-        assertEquals(expectedWaypoints, shortestRoute.waypoints(), "Waypoints for complex graph. Actual: " + shortestRoute.waypoints());
+        // Assuming the implementation is deterministic for the shortest path.
+        assertEquals(expectedShortestWaypoints, shortestRoute.waypoints(), "Shortest waypoints for complex graph. Actual: " + shortestRoute.waypoints());
+        
+        assertNotNull(longestRoute, "Longest route should not be null for complex graph");
+        assertNotNull(longestRoute.waypoints(), "Longest route waypoints should not be null");
+        assertFalse(longestRoute.waypoints().isEmpty(), "Longest route waypoints should not be empty");
+        assertEquals(8, longestRoute.waypoints().size(), "Longest route should visit all locations");
+        // The value 898 is from https://github.com/mariolutc/advent-of-code-2015/blob/master/day9/day9.org
+        assertEquals(898L, longestRoute.distance(), "Longest distance for complex graph. Expected based on external calculation.");
+        // We won't assert the exact longest path waypoints due to potential multiple paths with the same max distance
+        // and the complexity of listing them all or ensuring deterministic output for this specific path.
+        // However, we ensure it's a valid path covering all cities.
+        assertEquals(shortestRoute.waypoints().size(), longestRoute.waypoints().size(), "Longest route should visit the same number of locations as shortest.");
+        assertTrue(longestRoute.distance() >= shortestRoute.distance(), "Longest distance should be greater than or equal to shortest distance.");
     }
 }


### PR DESCRIPTION
This commit introduces the calculation of the longest route that visits all specified locations.

Modifications include:
- Added `longestRoute` field of type `Route` to the `Routes` record.
- Updated `Day9.calculateRoutes()` to compute and store the `longestRoute` alongside the `shortestRoute`. This involves iterating through all permutations of locations, calculating the total distance for each, and keeping track of the maximum distance found.
- Handled edge cases such as no locations (empty route, 0 distance) and a single location (route with that location, 0 distance) for both shortest and longest routes.
- Updated `Day9Test.java` to include assertions for `longestRoute.distance()` and `longestRoute.waypoints()` in existing tests. This ensures that the longest route is correctly calculated for various scenarios, including the Advent of Code example (shortest: 605, longest: 982), empty inputs, single locations, and more complex graphs.
- Removed unnecessary comments from `Day9Test.java` and confirmed all tests pass.