### PR TITLE
Add test for LookAndSay after 50 iterations

### DIFF
--- a/src/test/java/tar/calion/aoc/year2015/day10/LookAndSayTest.java
+++ b/src/test/java/tar/calion/aoc/year2015/day10/LookAndSayTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import tar.calion.aoc.year2015.day10.LookAndSay;
+import org.junit.jupiter.api.Test;
 
 public class LookAndSayTest {
 
@@ -27,5 +28,23 @@ public class LookAndSayTest {
     })
     void testLookAndSay(String input, String expected) {
         assertEquals(expected, LookAndSay.lookAndSay(input));
+    }
+
+    @Test
+    void testLookAndSayFortyTimes() {
+        String sequence = "3113322113";
+        for (int i = 0; i < 40; i++) {
+            sequence = LookAndSay.lookAndSay(sequence);
+        }
+        assertEquals(329356, sequence.length());
+    }
+
+    @Test
+    void testLookAndSayFiftyTimes() {
+        String sequence = "3113322113";
+        for (int i = 0; i < 50; i++) {
+            sequence = LookAndSay.lookAndSay(sequence);
+        }
+        assertEquals(4666278, sequence.length());
     }
 }


### PR DESCRIPTION
This commit introduces a new test case to LookAndSayTest.java to verify the behavior of the LookAndSay.lookAndSay() method when applied 50 times.

The test method, testLookAndSayFiftyTimes, starts with the initial sequence "3113322113" and applies the lookAndSay transformation 50 times. It then asserts that the length of the resulting sequence is 4666278.